### PR TITLE
Fix regex

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -8,7 +8,7 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins 'http://localhost:3000',
-            /https:\/\/mywordlist-[a-z0-9-]+.herokuapp.com/
+            /https:\/\/[a-z0-9-]+.herokuapp.com/
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
Heroku app names for the frontend client do not always start with my-wordlist